### PR TITLE
fix a bug: when open a *.gz file for reading or writing, the gzip cod…

### DIFF
--- a/kivakit-resource/src/main/java/com/telenav/kivakit/filesystem/File.java
+++ b/kivakit-resource/src/main/java/com/telenav/kivakit/filesystem/File.java
@@ -615,13 +615,13 @@ public class File extends BaseWritableResource implements FileSystemObject
     @Override
     public InputStream onOpenForReading()
     {
-        return service.openForReading();
+        return service.onOpenForReading();
     }
 
     @Override
     public OutputStream onOpenForWriting()
     {
-        return service.openForWriting();
+        return service.onOpenForWriting();
     }
 
     /**


### PR DESCRIPTION
fix a bug: when open a *.gz file for reading or writing, the gzip codec will be added twice to the input/output streaming

