### PR TITLE
Structural POM Cleanup

### DIFF
--- a/kivakit-application/pom.xml
+++ b/kivakit-application/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-application</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-collections/pom.xml
+++ b/kivakit-collections/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-collections</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-commandline/pom.xml
+++ b/kivakit-commandline/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-commandline</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-component/pom.xml
+++ b/kivakit-component/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-component</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-conversion/pom.xml
+++ b/kivakit-conversion/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-conversion</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-core/pom.xml
+++ b/kivakit-core/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-core</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-extraction/pom.xml
+++ b/kivakit-extraction/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-extraction</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-interfaces/pom.xml
+++ b/kivakit-interfaces/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-interfaces</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-internal/pom.xml
+++ b/kivakit-internal/pom.xml
@@ -1,20 +1,10 @@
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-<!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
-<!--  Licensed under Apache License, Version 2.0                                                                     -->
-<!--                                                                                                                 -->
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" xmlns = "http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
-    </parent>
-
+    <groupId>com.telenav.kivakit</groupId>
+    <version>1.5.1-SNAPSHOT</version>
     <artifactId>kivakit-internal</artifactId>
     <description>Test packages and similar, generally of interest only to developers of KivaKit</description>
     <packaging>pom</packaging>

--- a/kivakit-internal/test-internal/pom.xml
+++ b/kivakit-internal/test-internal/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
 <!--  © 2011-2022 Telenav, Inc.                                                                                      -->
@@ -11,11 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
-        <relativePath/>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-test-internal</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-internal/unit-tests/core/pom.xml
+++ b/kivakit-internal/unit-tests/core/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
 <!--  © 2011-2022 Telenav, Inc.                                                                                      -->
@@ -11,11 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
-        <relativePath/>
+        <relativePath>../../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-core-tests</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-internal/unit-tests/pom.xml
+++ b/kivakit-internal/unit-tests/pom.xml
@@ -1,20 +1,10 @@
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-<!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
-<!--  Licensed under Apache License, Version 2.0                                                                     -->
-<!--                                                                                                                 -->
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" xmlns = "http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
-    </parent>
-
+    <groupId>com.telenav.kivakit</groupId>
+    <version>1.5.1-SNAPSHOT</version>
     <artifactId>kivakit-unit-tests</artifactId>
     <description>Unit-test-only projects for cases where test-support classes that depend on
                  that project would create a circular dependency.</description>

--- a/kivakit-internal/unit-tests/resource/pom.xml
+++ b/kivakit-internal/unit-tests/resource/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
 <!--  © 2011-2022 Telenav, Inc.                                                                                      -->
@@ -11,11 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
-        <relativePath/>
+        <relativePath>../../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-resource-tests</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-mixins/pom.xml
+++ b/kivakit-mixins/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-mixins</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-network/core/pom.xml
+++ b/kivakit-network/core/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-network</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-network-core</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-network/email/pom.xml
+++ b/kivakit-network/email/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-network</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-network-email</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-network/ftp/pom.xml
+++ b/kivakit-network/ftp/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-network</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-network-ftp</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-network/http/pom.xml
+++ b/kivakit-network/http/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-network</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-network-http</artifactId>
 
     <packaging>jar</packaging>

--- a/kivakit-network/pom.xml
+++ b/kivakit-network/pom.xml
@@ -1,20 +1,10 @@
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-<!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
-<!--  Licensed under Apache License, Version 2.0                                                                     -->
-<!--                                                                                                                 -->
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" xmlns = "http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
-    </parent>
-
+    <groupId>com.telenav.kivakit</groupId>
+    <version>1.5.1-SNAPSHOT</version>
     <artifactId>kivakit-network</artifactId>
     <packaging>pom</packaging>
 

--- a/kivakit-network/socket/pom.xml
+++ b/kivakit-network/socket/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-network</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-network-socket</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-resource/pom.xml
+++ b/kivakit-resource/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-resource</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-serialization/core/pom.xml
+++ b/kivakit-serialization/core/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-serialization</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-serialization-core</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-serialization/gson/pom.xml
+++ b/kivakit-serialization/gson/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-serialization</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-serialization-gson</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-serialization/kryo/pom.xml
+++ b/kivakit-serialization/kryo/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-serialization</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-serialization-kryo</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-serialization/pom.xml
+++ b/kivakit-serialization/pom.xml
@@ -1,20 +1,10 @@
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-<!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
-<!--  Licensed under Apache License, Version 2.0                                                                     -->
-<!--                                                                                                                 -->
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" xmlns = "http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
-    </parent>
-
+    <groupId>com.telenav.kivakit</groupId>
+    <version>1.5.1-SNAPSHOT</version>
     <artifactId>kivakit-serialization</artifactId>
     <packaging>pom</packaging>
 

--- a/kivakit-serialization/properties/pom.xml
+++ b/kivakit-serialization/properties/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit-serialization</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-serialization-properties</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-settings/pom.xml
+++ b/kivakit-settings/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-settings</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-test/pom.xml
+++ b/kivakit-test/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
 <!--  © 2011-2022 Telenav, Inc.                                                                                      -->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-test</artifactId>
     <packaging>jar</packaging>
 

--- a/kivakit-validation/pom.xml
+++ b/kivakit-validation/pom.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
 <!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
+<!--  © 2011-2022 Telenav, Inc.                                                                                      -->
 <!--  Licensed under Apache License, Version 2.0                                                                     -->
 <!--                                                                                                                 -->
 <!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
@@ -11,10 +12,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.telenav.kivakit</groupId>
-        <artifactId>kivakit</artifactId>
+        <artifactId>superpom</artifactId>
         <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../superpom</relativePath>
     </parent>
-
     <artifactId>kivakit-validation</artifactId>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,10 @@
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-<!--                                                                                                                 -->
-<!--  © 2011-2021 Telenav, Inc.                                                                                      -->
-<!--  Licensed under Apache License, Version 2.0                                                                     -->
-<!--                                                                                                                 -->
-<!--/////////////////////////////////////////////////////////////////////////////////////////////////////////////////-->
-
-<!--suppress MavenModelInspection -->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" xmlns = "http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.telenav.kivakit</groupId>
-        <artifactId>superpom</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
-        <relativePath>superpom/pom.xml</relativePath>
-    </parent>
-
+    <groupId>com.telenav.kivakit</groupId>
     <artifactId>kivakit</artifactId>
     <version>1.5.1-SNAPSHOT</version>
 
@@ -117,4 +104,3 @@
     </modules>
 
 </project>
-


### PR DESCRIPTION
  * Bill-of-materials POMs now have no parent (they do not need one)
  * JAR POMs now all directly parent to `superpom`
    * `<relativePath>` now points to `superpom` within the repository.  In the long run, it would be preferable to
      1. Split `superpom` into its own repo
      2. Use `<relativePath/>` so projects are not tied to a specific layout on disk.  That can be done now,
         but it creates one non-intuitive problem:  Maven cannot find the `superpom` as parent of JAR projects
         even though it is about to build it, so a fresh checkout has to be bootstrapped by running `mvn -f superpom install`
         once if no copy under `~/.m2/repository` already.  Not a showstopper, but not exactly intuitive.

Tested by deleting `~/.m2/repository/com/telenav` and building from scratch, to ensure there are no parent resolution problems.

