### PR TITLE
"'Topologically sort modules to potentially work around issues with broken parallel builds'"

### DIFF
--- a/kivakit-internal/pom.xml
+++ b/kivakit-internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-intermediate-bom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath/>
     </parent>
 

--- a/kivakit-internal/tests/pom.xml
+++ b/kivakit-internal/tests/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-intermediate-bom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath/>
     </parent>
 

--- a/kivakit-internal/tests/pom.xml
+++ b/kivakit-internal/tests/pom.xml
@@ -30,8 +30,8 @@
         Support for testing of core classes to avoid circular dependencies.
     </description>
     <modules>
-        <module>core</module>
         <module>resource</module>
+        <module>core</module>
     </modules>
 
 </project>

--- a/kivakit-network/pom.xml
+++ b/kivakit-network/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-intermediate-bom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath/>
     </parent>
 

--- a/kivakit-network/pom.xml
+++ b/kivakit-network/pom.xml
@@ -29,10 +29,10 @@
 
     <modules>
 
-        <module>core</module>
-        <module>socket</module>
-        <module>http</module>
         <module>ftp</module>
+        <module>core</module>
+        <module>http</module>
+        <module>socket</module>
         <module>email</module>
 
     </modules>

--- a/kivakit-serialization/pom.xml
+++ b/kivakit-serialization/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-intermediate-bom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath/>
     </parent>
 

--- a/kivakit-serialization/pom.xml
+++ b/kivakit-serialization/pom.xml
@@ -28,11 +28,11 @@
     <packaging>pom</packaging>
     
     <modules>
-        <module>core</module>
-        <module>properties</module>
         <module>kryo</module>
-        <module>gson</module>
         <module>kryo-testing</module>
+        <module>core</module>
+        <module>gson</module>
+        <module>properties</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,21 +35,21 @@
     <modules>
         
         <module>kivakit-interfaces</module>
+        <module>kivakit-testing</module>
+        <module>kivakit-internal</module>
         <module>kivakit-mixins</module>
         <module>kivakit-core</module>
+        <module>kivakit-validation</module>
         <module>kivakit-collections</module>
         <module>kivakit-conversion</module>
         <module>kivakit-extraction</module>
-        <module>kivakit-validation</module>
+        <module>kivakit-commandline</module>
         <module>kivakit-resource</module>
         <module>kivakit-serialization</module>
         <module>kivakit-settings</module>
         <module>kivakit-network</module>
         <module>kivakit-component</module>
-        <module>kivakit-commandline</module>
         <module>kivakit-application</module>
-        <module>kivakit-internal</module>
-        <module>kivakit-testing</module>
         
     </modules>
     

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-project-family</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
"'Topologically sort modules to potentially work around issues with broken parallel builds'



Creating Pull Requests In
-------------------------

  * kivakit topo-sort-modules -> develop
  * kivakit-examples topo-sort-modules -> develop
  * kivakit-extensions topo-sort-modules -> develop
  * kivakit-stuff topo-sort-modules -> develop
  * mesakit topo-sort-modules -> develop
  * mesakit-examples topo-sort-modules -> develop
  * mesakit-extensions topo-sort-modules -> develop
  * telenav-superpom topo-sort-modules -> develop
  * jonstuff topo-sort-modules -> develop


Metadata
--------

  * Invoked on com.telenav:telenav-build:2.0.2
  * SearchNonce: rNoMFcQ5V1-rgwrbn

##### Provenance

Generated by cactus: *cactus-maven-plugin* version _1.5.24_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-08-20T09:50:21Z
  * Plugin-Build:	tungsten bobblehead
  * Plugin-Date:	2022.08.20
  * Plugin-Commit:	2586695b880771254e2daf63f2f5f8a5cca1c96b
  * Plugin-Repo-Clean:	false
"